### PR TITLE
fix: initialize time counter correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ $(BUILD):
 # TESTS
 tests: $(BUILD) $(TEST_BINS)
 
+
 # Regra genérica para todos os testes
 $(BUILD)/%test: tests/%test.cpp $(SRC)
 	$(CXX) $(CXXFLAGS) $< $(SRC) -o $@
@@ -31,6 +32,7 @@ $(BUILD)/%test: tests/%test.cpp $(SRC)
 # CLOCKWORK
 runClock: $(BUILD) $(CLOCK_BIN)
 	./$(CLOCK_BIN)
+
 
 
 $(CLOCK_BIN): $(CLOCK_SRC) $(SRC)

--- a/include/chips.hpp
+++ b/include/chips.hpp
@@ -72,6 +72,7 @@ class Chip4029 {
                 throw std::invalid_argument("presetInputs requires 4 valid boolean values");
             }
             this->presetInputs = presetInputs;
+            this->outputs = presetInputs;
         }
 
         void setPresetEnable();

--- a/include/feedback.hpp
+++ b/include/feedback.hpp
@@ -5,6 +5,7 @@
 #include <string>
 #include <iostream>
 
+
 // Seven-segments display
 class Display{
     private:

--- a/src/chips.cpp
+++ b/src/chips.cpp
@@ -186,6 +186,7 @@ void Chip4029::clock() {
     if (presetEnable) {
         outputs = presetInputs;
         presetEnable = false;
+        return;
     }
 
     if (!carryIn) {

--- a/src/digitalClockwork.cpp
+++ b/src/digitalClockwork.cpp
@@ -270,6 +270,8 @@ class DigitalClockwork{
 
             cd4017 = chip4017;
             cd4040 = chip4040;
+
+            updateDisplays();
         }
 
         // Advances the system clock and updates the circuit based on the selected mode
@@ -308,7 +310,7 @@ int main(){
     std::array<Chip4029, 4> cd4029 = {
         Chip4029(presetZero),
         Chip4029(presetZero),
-        Chip4029(presetZero),
+        Chip4029({1,0,0,0}),
         Chip4029(presetZero)
     };
 
@@ -342,7 +344,7 @@ int main(){
 
 
     // instantiate the main clockwork controller
-       DigitalClockwork functions(
+    DigitalClockwork functions(
         ptr4029,
         ptr4511,
         ptr4081,

--- a/src/feedback.cpp
+++ b/src/feedback.cpp
@@ -1,6 +1,7 @@
 #include "feedback.hpp"
 #include <iostream>
 
+
 /*
     DISPLAY
 */


### PR DESCRIPTION
## Fix
The clock was always initialized at 00:00 AM, whereas the original project intended 
it to start at 01:00 AM, as expected in a 12-hour clock configuration. The fix involved 
changing the preset value of the 3rd CD4029 from {0,0,0,0} to {1,0,0,0}, corresponding 
to the first digit of the hours, as specified in the original schematic.

## Code
```cpp
const std::array<bool, 4> presetZero = {0,0,0,0};
    
// instantiate BCD counters, decoders and AND gate chips
std::array<Chip4029, 4> cd4029 = {
      Chip4029(presetZero),
      Chip4029(presetZero),
      Chip4029({1,0,0,0}),        // <-- here. Before was Chip4029(presetZero)
      Chip4029(presetZero)
};
```

## Other Changes
- The `Chip4029` constructor now initializes `outputs` directly from `presetInputs`, 
  ensuring the preset value is reflected immediately without requiring a clock pulse.
- The `clock()` method now returns early after applying a preset, preventing 
  an unintended increment on the same cycle.
- `updateDisplays()` is now called at the end of the `DigitalClockwork` constructor, 
  ensuring the display reflects the initial preset state before the first clock cycle.