### PR TITLE
refactor: cross-platform keyboard capture (Linux, Windows, macOS)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,42 @@
 CXX = g++
-CXXFLAGS = -std=c++17 -Wall -Wextra -Iinclude $(shell pkg-config --cflags libevdev)
+CXXFLAGS = -std=c++17 -Wall -Wextra -Iinclude
+LIBS = -lpthread -lasound
 
-LIBS = $(shell pkg-config --libs libevdev) -lasound
 SRC = src/chips.cpp src/freqGenerator.cpp src/feedback.cpp
-
 BUILD = builds
-TEST_NAMES = 4511 4029 4040 4017 4013 4063 555 frequency keyboard
 
+TEST_NAMES = 4511 4029 4040 4017 4013 4063 555 frequency keyboard
 TEST_BINS = $(addprefix $(BUILD)/, $(addsuffix test, $(TEST_NAMES)))
+
 CLOCK_SRC = src/main.cpp src/digitalClockwork.cpp src/digitalAlarm.cpp
 CLOCK_BIN = $(BUILD)/digitalClock
 
-.PHONY: all tests clean runClock
+
+# OS DETECTION
+UNAME_S := $(shell uname -s 2>/dev/null)
+
+ifeq ($(UNAME_S),Linux)
+KEYBOARD_SRC := src/keyboard_linux.cpp
+CXXFLAGS += $(shell pkg-config --cflags libevdev)
+LIBS += $(shell pkg-config --libs libevdev)
+endif
+
+ifeq ($(UNAME_S),Darwin)
+KEYBOARD_SRC := src/keyboard_macintosh.cpp
+LIBS += -framework ApplicationServices -framework Carbon
+endif
+
+ifeq ($(OS),Windows_NT)
+KEYBOARD_SRC := src/keyboard_windows.cpp
+endif
+
+
+CLOCK_SRC += $(KEYBOARD_SRC)
+
+.PHONY: all tests clean clock
 
 all: tests
+
 
 $(BUILD):
 	mkdir -p $(BUILD)
@@ -25,23 +48,15 @@ tests: $(BUILD) $(TEST_BINS)
 $(BUILD)/%test: tests/%test.cpp $(SRC)
 	$(CXX) $(CXXFLAGS) $< $(SRC) -o $@ $(LIBS)
 
-
-$(BUILD)/keyboardtest: tests/keyboardtest.cpp
-	$(CXX) $(CXXFLAGS) $< -o $@ $(LIBS)
-
-
 $(BUILD)/555test: tests/555test.cpp $(SRC)
-	$(CXX) $(CXXFLAGS) $< $(SRC) -o $@ $(LIBS) -lasound
+	$(CXX) $(CXXFLAGS) $< $(SRC) -o $@ $(LIBS)
 
-
-$(BUILD)/keyboardtest: tests/keyboardtest.cpp
-	$(CXX) $(CXXFLAGS) $< -o $@ $(shell pkg-config --libs libevdev)
+$(BUILD)/keyboardtest: tests/keyboardtest.cpp $(KEYBOARD_SRC)
+	$(CXX) $(CXXFLAGS) $< $(KEYBOARD_SRC) -o $@ $(LIBS)
 
 
 # CLOCKWORK
-runClock: $(BUILD) $(CLOCK_BIN)
-	./$(CLOCK_BIN)
-
+clockwork: $(BUILD) $(CLOCK_BIN)
 
 $(CLOCK_BIN): $(CLOCK_SRC) $(SRC)
 	$(CXX) $(CXXFLAGS) $^ -o $@ $(LIBS)
@@ -50,4 +65,3 @@ $(CLOCK_BIN): $(CLOCK_SRC) $(SRC)
 # CLEAR
 clean:
 	rm -rf $(BUILD)
-

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This repository serves as a personal experimental environment for:
 
 ## Extensions
 
-As a final assignment for the Digital Systems course, offered by the Computer Department at Universidade Federal de Sergipe (UFS) and taught by Prof. Dr. Calebe Micael de Oliveira Conceição and Prof. Rodolfo Botto de Barros Garcia, we were challenged to extend the Digital Clockwork with a fully functional alarm system.
+1. As a final assignment for the Digital Systems course, offered by the Computer Department at Universidade Federal de Sergipe (UFS) and taught by Prof. Dr. Calebe Micael de Oliveira Conceição and Prof. Rodolfo Botto de Barros Garcia, we were challenged to extend the Digital Clockwork with a fully functional alarm system.
 
 ## Operating System Compatibility
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# The Digital Clockwork Simulator
+# A Digital Clockwork Simulator
 
 Viddy well, little brother. This project is queer, queer like a clockwork orange!
 
-**The Digital Clockwork Simulator** is a digital clock circuit simulator inspired by a project created by Wagner Rambo and presented on his YouTube channel, **WR Kits**.
+**A Digital Clockwork Simulator** is a digital clock circuit simulator inspired by a project created by Wagner Rambo and presented on his YouTube channel, **WR Kits**.
 
 This simulator was developed as a way to study digital circuit behavior, low-level hardware concepts, discrete logic, and the internal operation of integrated circuits such as **CD4017**, **CD4029**, **CD4511**, and others used in the original design.
 
@@ -23,17 +23,38 @@ This repository serves as a personal experimental environment for:
 
 ## Extensions
 
-1. As a final assignment for the Digital Systems course, offered by the Computer Department at Universidade Federal de Sergipe (UFS) and taught by Prof. Dr. Calebe Micael de Oliveira Conceição and Prof. Rodolfo Botto de Barros Garcia, we were challenged to extend the Digital Clockwork with a fully functional alarm system.
+As a final assignment for the Digital Systems course, offered by the Computer Department at Universidade Federal de Sergipe (UFS) and taught by Prof. Dr. Calebe Micael de Oliveira Conceição and Prof. Rodolfo Botto de Barros Garcia, we were challenged to extend the Digital Clockwork with a fully functional alarm system.
 
-* **g++** — C++ compiler with C++17 support
+## Operating System Compatibility
+
+The simulator runs on **Linux, Windows, and macOS**. Keyboard capture is implemented separately for each platform behind a common interface (`include/keyboard.hpp`):
+
+| Platform | Implementation file          | Mechanism                                                      |
+|----------|------------------------------|----------------------------------------------------------------|
+| Linux    | `src/keyboard_linux.cpp`     | `libevdev`, reading raw kernel events from `/dev/input/eventX` |
+| Windows  | `src/keyboard_windows.cpp`   | `GetAsyncKeyState` (WinAPI), polling-based, no window required |
+| macOS    | `src/keyboard_macintosh.cpp` | `CGEventTap`, system-wide event tap, no window required        |
+
+Only one of these three files is compiled at a time — the Makefile detects the host OS (`uname -s` on Linux/macOS, `$(OS)` on Windows) and selects the correct one automatically. `main.cpp` is identical across all platforms; it only calls the functions declared in `keyboard.hpp` and never knows which implementation is behind them.
+
+> **macOS note:** `CGEventTap` requires Accessibility permission granted to the compiled binary in *System Settings > Privacy & Security > Accessibility*. Without it, the tap is created successfully but silently receives no events — there is no error message, so if keys don't seem to register, check this first.
+
+## Dependencies
+
+To build and run this project, the following must be installed:
+
+* **g++** — C++17 or later
 * **make** — build automation tool used to compile the project
-* **libevdev** — used for real-time keyboard input detection on Linux
+* **libasound2-dev** — ALSA library for audio output (Linux)
+* **libevdev-dev** — Linux keyboard input handling (Linux only)
 
-To install it on Ubuntu/Debian:
+On Debian/Ubuntu:
 
 ```bash
-sudo apt install libevdev-dev
+sudo apt install g++ libasound2-dev libevdev-dev
 ```
+
+Windows and macOS builds rely only on system frameworks already available with a standard C++ toolchain (WinAPI on Windows; `ApplicationServices` and `Carbon` on macOS) — no extra packages are required beyond `g++`/`clang` and `make`.
 
 ## Build and Run
 
@@ -42,30 +63,19 @@ To compile and run the Digital Clockwork simulator:
 ```bash
 git clone https://github.com/FrankSteps/digital-clockwork-simulator
 cd digital-clockwork-simulator
-sudo make runClock
+make clockwork
+./builds/digitalClock input/days.week
 ```
 
-> **Note:** Running the simulator requires `sudo` because it reads directly from `/dev/input/eventX`, which is a privileged device file on Linux.
+> **Note:** Never run `make` or the compiled binary with `sudo`. Doing so runs the process outside your user session, which breaks ALSA audio output (`Buzzer error: could not open audio device`). If `libevdev` fails to open `/dev/input/eventX` due to a permissions error, add your user to the `input` group instead — see [Known Limitations](#known-limitations) below.
 
-```bash
-sudo ./builds/digitalClock
-```
-
-The keyboard input device is hardcoded to `/dev/input/event4`. If your keyboard is mapped to a different event number, you can check it with:
+The keyboard input device is hardcoded to `/dev/input/event4` on Linux. If your keyboard is mapped to a different event number, you can check it with:
 
 ```bash
 cat /proc/bus/input/devices | grep -A5 -i "keyboard"
 ```
 
-And update the path in `src/digitalClockwork.cpp` accordingly.
-
-## Controls
-
-|   Key   |               Action              |
-|---------|-----------------------------------|
-|   `F`   | Fast mode — accelerates the clock |
-|   `S`   | Slow mode — decelerates the clock |
-| Release | Returns to default speed          |
+And update the path in `src/keyboard_linux.cpp` accordingly.
 
 ## Project Structure
 
@@ -79,20 +89,24 @@ digital-clockwork-simulator
 │   ├── documentation.pdf
 │   └── documentation.tex
 ├── include                          # Header files
-│   ├── chips.hpp
-│   ├── digitalAlarm.hpp
-│   ├── digitalClockwork.hpp
-│   ├── feedback.hpp
-│   └── freqGenerator.hpp
-├── input                            # Input configurations to simulate the switches"
-│   └── days.week
+│   ├── chips.hpp
+│   ├── digitalAlarm.hpp
+│   ├── digitalClockwork.hpp
+│   ├── feedback.hpp
+│   ├── freqGenerator.hpp
+│   └── keyboard.hpp                 # Platform-agnostic keyboard interface
+├── input                            # Input configurations to simulate the switches
+│   └── days.week
 ├── src                              # Source code files
-│   ├── chips.cpp
-│   ├── digitalAlarm.cpp
-│   ├── digitalClockwork.cpp
-│   ├── feedback.cpp
-│   ├── freqGenerator.cpp
-│   └── main.cpp
+│   ├── chips.cpp
+│   ├── digitalAlarm.cpp
+│   ├── digitalClockwork.cpp
+│   ├── feedback.cpp
+│   ├── freqGenerator.cpp
+│   ├── keyboard_linux.cpp           # Linux keyboard implementation (libevdev)
+│   ├── keyboard_windows.cpp         # Windows keyboard implementation (GetAsyncKeyState)
+│   ├── keyboard_macintosh.cpp       # macOS keyboard implementation (CGEventTap)
+│   └── main.cpp
 ├── tests                            # Unit tests
 │   ├── 4013test.cpp 
 │   ├── 4017test.cpp 
@@ -108,32 +122,6 @@ digital-clockwork-simulator
 └── README.md                        # Project documentation
 ```
 
-## Dependencies
-
-To build and run this project, the following must be installed:
-
-* **g++** — C++17 or later
-* **libasound2-dev** — ALSA library for audio output
-* **libevdev-dev** — Linux keyboard input handling
-
-On Debian/Ubuntu:
-
-```bash
-sudo apt install g++ libasound2-dev libevdev-dev
-```
-
-## Build and run
-
-To compile and run the Digital Clockwork simulator:
-
-```bash
-git clone https://github.com/FrankSteps/digital-clockwork-simulator
-
-cd digital-clockwork-simulator
-
-make runClock
-```
-
 ![The Digital Clockwork Simulator + The Amazing Digital Alarm](assets/a_digital_clockwork/simulator.png)
 
 ## Using the Alarm and the Clockwork
@@ -146,6 +134,7 @@ The `.week` file, located in the `input` folder, simulates seven physical ON/OFF
 # Weekday alarm configuration
 # Set 1 to enable the alarm on that day, 0 to disable it
 # Lines starting with # are treated as comments
+
 SUN = 0     # comments can be inserted this way
 MON = 1
 TUE = 1
@@ -168,9 +157,17 @@ Comments are supported via `#`. The remaining configuration is done directly via
 
 ## Known Limitations
 
-The current Linux implementation captures keyboard input via `libevdev`, which requires read access to `/dev/input/eventX`. This demands either `sudo` or adding the user to the `input` group via `newgrp input`, which is far from ideal.
+* **Duplication across platform files.** `keyboard_linux.cpp`, `keyboard_windows.cpp`, and `keyboard_macintosh.cpp` each implement the same interface independently — there is no shared abstraction between them beyond `keyboard.hpp`. Changing the tracked keys or the edge-detection logic requires updating all three files individually. This tradeoff was accepted to keep `main.cpp` untouched and each platform file self-contained and easy to reason about in isolation, at the cost of manual synchronization.
+* **Linux keyboard permissions.** The Linux implementation captures keyboard input via `libevdev`, which requires read access to `/dev/input/eventX`. Add your user to the `input` group and reload it, without using `sudo`:
 
-A migration to **SDL2** is planned on a dedicated branch, which will eliminate this requirement and make keyboard handling cross-platform and permission-free.
+```bash
+  sudo usermod -aG input $USER
+  newgrp input
+```
+
+* **macOS Accessibility permission.** As noted above, `CGEventTap` requires the compiled binary to be explicitly granted Accessibility permission, or it silently receives no keyboard events.
+* **Hardcoded Linux input device.** The Linux implementation reads from `/dev/input/event4` by default; this may need to be changed depending on the host machine's device enumeration (see Build and Run above).
+* **Window focus.** Keyboard capture is not tied to window focus on any platform: `libevdev` reads raw kernel events regardless of which window is active, `GetAsyncKeyState` polls global key state system-wide, and `CGEventTap` is a system-wide event tap. This means a tracked key (`F`, `S`, `P`, `A`, `R`, `D`) is registered by the simulator even if another application or window is focused, as long as the program is running.
 
 ## Important Note
 

--- a/include/keyState.hpp
+++ b/include/keyState.hpp
@@ -1,0 +1,14 @@
+#ifndef KEYSTATE_HPP
+#define KEYSTATE_HPP
+
+// current state of each key tracked by the program, filled by the platform-specific poll function
+struct KeyState {
+    bool F;
+    bool S;
+    bool P;
+    bool A;
+    bool R;
+    bool D;
+};
+
+#endif

--- a/include/keyboard.hpp
+++ b/include/keyboard.hpp
@@ -1,0 +1,24 @@
+#ifndef KEYBOARD_HPP
+#define KEYBOARD_HPP
+
+#include "keyState.hpp"
+
+// interface implemented once per platform: keyboard_linux.cpp, keyboard_windows.cpp, keyboard_macos.cpp
+// only one of these three .cpp files is compiled at a time, selected by the Makefile
+
+// opens whatever keyboard capture mechanism the platform uses
+void initKeyboard();
+
+// returns the current state of the tracked keys
+KeyState pollKeys();
+
+// closes the keyboard capture mechanism
+void closeKeyboard();
+
+// terminal configuration, called once before the main loop
+void terminalSetup();
+
+// terminal restoration, called once after the main loop
+void terminalTeardown();
+
+#endif

--- a/src/keyboard_linux.cpp
+++ b/src/keyboard_linux.cpp
@@ -1,0 +1,68 @@
+/*
+[LINUX]
+    Reads keyboard events via libevdev from the raw kernel device.
+*/
+
+#include "keyboard.hpp"
+
+#include <iostream>                                     // std::cerr
+#include <cstdlib>                                       // system(), EXIT_FAILURE
+
+#include <libevdev/libevdev.h>                          // keyboard input events
+#include <fcntl.h>                                       // open(), O_RDONLY, O_NONBLOCK
+#include <unistd.h>                                      // close()
+
+
+static int fd = -1;
+static struct libevdev* dev = nullptr;
+static KeyState state = {false, false, false, false, false, false};
+
+
+void initKeyboard(){
+    fd = open("/dev/input/event4", O_RDONLY | O_NONBLOCK);
+
+    if(fd < 0){
+        std::cerr << "The file couldn't open\n";
+        exit(EXIT_FAILURE);
+    }
+
+    libevdev_new_from_fd(fd, &dev);
+}
+
+
+KeyState pollKeys(){
+    struct input_event ev;
+
+    if(libevdev_next_event(dev, LIBEVDEV_READ_FLAG_NORMAL, &ev) == 0){
+        if(ev.type == EV_KEY){
+            bool pressed = (ev.value == 1);
+            bool released = (ev.value == 0);
+
+            if(ev.code == KEY_F && pressed){ state.F = true; } if(ev.code == KEY_F && released){ state.F = false; }
+            if(ev.code == KEY_S && pressed){ state.S = true; } if(ev.code == KEY_S && released){ state.S = false; }
+            if(ev.code == KEY_P && pressed){ state.P = true; } if(ev.code == KEY_P && released){ state.P = false; }
+            if(ev.code == KEY_A && pressed){ state.A = true; } if(ev.code == KEY_A && released){ state.A = false; }
+            if(ev.code == KEY_R && pressed){ state.R = true; } if(ev.code == KEY_R && released){ state.R = false; }
+            if(ev.code == KEY_D && pressed){ state.D = true; } if(ev.code == KEY_D && released){ state.D = false; }
+        }
+    }
+
+    return state;
+}
+
+
+void closeKeyboard(){
+    libevdev_free(dev);
+    close(fd);
+}
+
+
+void terminalSetup(){
+    system("clear");
+    system("stty -echo");
+}
+
+
+void terminalTeardown(){
+    system("stty echo");
+}

--- a/src/keyboard_macintosh.cpp
+++ b/src/keyboard_macintosh.cpp
@@ -1,0 +1,103 @@
+/*
+[MACOS]
+    Reads keyboard events via CGEventTap (system-wide, no window required).
+
+    NOTE: requires Accessibility permission granted to the binary in System Settings > Privacy & Security > Accessibility, 
+    otherwise the event tap silently receives no events.
+*/
+
+#include "keyboard.hpp"
+
+#include <iostream>                                      // std::cerr
+#include <cstdlib>                                       // system(), EXIT_FAILURE
+
+#include <ApplicationServices/ApplicationServices.h>     // CGEventTap
+#include <Carbon/Carbon.h>                               // kVK_ANSI_* virtual keycodes
+
+
+#define VK_KEY_F kVK_ANSI_F
+#define VK_KEY_S kVK_ANSI_S
+#define VK_KEY_P kVK_ANSI_P
+#define VK_KEY_A kVK_ANSI_A
+#define VK_KEY_R kVK_ANSI_R
+#define VK_KEY_D kVK_ANSI_D
+
+
+static CFMachPortRef tap = nullptr;
+static CFRunLoopSourceRef runLoopSource = nullptr;
+static KeyState state = {false, false, false, false, false, false};
+
+
+CGEventRef keyTapCallback(CGEventTapProxy proxy, CGEventType type, CGEventRef event, void* refcon){
+    if(type == kCGEventKeyDown || type == kCGEventKeyUp){
+        CGKeyCode code = static_cast<CGKeyCode>(CGEventGetIntegerValueField(event, kCGKeyboardEventKeycode));
+        bool pressed = (type == kCGEventKeyDown);
+
+        if(code == VK_KEY_F){ 
+            state.F = pressed; 
+        }
+
+        if(code == VK_KEY_S){ 
+            state.S = pressed; 
+        }
+
+        if(code == VK_KEY_P){ 
+            state.P = pressed; 
+        }
+
+        if(code == VK_KEY_A){ 
+            state.A = pressed; 
+        }
+
+        if(code == VK_KEY_R){ 
+            state.R = pressed; 
+        }
+
+        if(code == VK_KEY_D){ 
+            state.D = pressed; 
+        }
+    }
+
+    return event;
+}
+
+
+void initKeyboard(){
+    CGEventMask mask = CGEventMaskBit(kCGEventKeyDown) | CGEventMaskBit(kCGEventKeyUp);
+
+    tap = CGEventTapCreate(kCGSessionEventTap, kCGHeadInsertEventTap, kCGEventTapOptionListenOnly, mask, keyTapCallback, nullptr);
+
+    if(tap == nullptr){
+        std::cerr << "The event tap couldn't be created (check Accessibility permission)\n";
+        exit(EXIT_FAILURE);
+    }
+
+    runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0);
+    CFRunLoopAddSource(CFRunLoopGetCurrent(), runLoopSource, kCFRunLoopCommonModes);
+    CGEventTapEnable(tap, true);
+}
+
+
+KeyState pollKeys(){
+    CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0, true);
+    return state;
+}
+
+
+void closeKeyboard(){
+    CGEventTapEnable(tap, false);
+    CFRunLoopRemoveSource(CFRunLoopGetCurrent(), runLoopSource, kCFRunLoopCommonModes);
+    CFRelease(runLoopSource);
+    CFRelease(tap);
+}
+
+
+void terminalSetup(){
+    system("clear");
+    system("stty -echo");
+}
+
+
+void terminalTeardown(){
+    system("stty echo");
+}

--- a/src/keyboard_windows.cpp
+++ b/src/keyboard_windows.cpp
@@ -1,0 +1,34 @@
+/*
+[WINDOWS]
+    Reads keyboard state via GetAsyncKeyState (polling, no window required).
+*/
+
+#include "keyboard.hpp"
+
+#include <cstdlib>                                        // system()
+#include <windows.h>                                      // GetAsyncKeyState
+
+
+void terminalTeardown(){}   // no equivalent to stty needed
+void initKeyboard(){}       // no handle to open: GetAsyncKeyState queries the system directly
+void closeKeyboard(){}      // nothing to close
+
+
+KeyState pollKeys(){
+    KeyState state;
+
+    state.F = (GetAsyncKeyState('F') & 0x8000) != 0;
+    state.S = (GetAsyncKeyState('S') & 0x8000) != 0;
+    state.P = (GetAsyncKeyState('P') & 0x8000) != 0;
+    state.A = (GetAsyncKeyState('A') & 0x8000) != 0;
+    state.R = (GetAsyncKeyState('R') & 0x8000) != 0;
+    state.D = (GetAsyncKeyState('D') & 0x8000) != 0;
+
+    return state;
+}
+
+
+
+void terminalSetup(){
+    system("cls");
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,6 +10,10 @@
     foram usados, respectivamente, para a declaração e implementação dos artifícios responsáveis pelo feedback visual do usuário 
     no terminal.
 
+    A leitura de teclado é feita por trás da interface declarada em keyboard.hpp, implementada uma vez por 
+    sistema operacional (keyboard_linux.cpp, keyboard_windows.cpp, keyboard_macos.cpp). Apenas um desses arquivos 
+    é compilado por vez, escolhido pelo Makefile de acordo com o SO detectado.
+
 [EN-US]
     A Digital Clockwork simulates the logic of a digital clock circuit inspired by the project of Wagner Rambo (WR Kits).
     The class "DigitalClockwork" orchestrates the interaction between BCD counters (CD4029), seven-segment decoders (CD4511), 
@@ -21,8 +25,9 @@
     respectively, for the declaration and implementation of the mechanisms responsible for providing visual feedback to the user in 
     the terminal.
 
-[LINUX]
-    This main.cpp is only for Linux users
+    Keyboard reading is done behind the interface declared in keyboard.hpp, implemented once per operating 
+    system (keyboard_linux.cpp, keyboard_windows.cpp, keyboard_macos.cpp). Only one of these files is compiled 
+    at a time, chosen by the Makefile based on the detected OS.
 */
 
 //libraries
@@ -32,36 +37,23 @@
 #include "chips.hpp"                                    // CD4029, CD4511, CD4081, CD4017, CD4040...
 #include "feedback.hpp"                                 // Display, Led...
 #include "freqGenerator.hpp"                            // Frequency generator
+#include "keyboard.hpp"                                 // platform keyboard interface
 
 #include <iostream>                                     // std::cout, std::cerr
 #include <cstdlib>                                      // system()
 #include <string>                                       // std::string
 #include <array>                                        // std::array
 
-#include <libevdev/libevdev.h>                          // keyboard input events
-#include <fcntl.h>                                      // open(), O_RDONLY, O_NONBLOCK
-#include <unistd.h>                                     // close()
-
 
 int main(int argc, char* argv[]){
     /*
     
         COMUNICATION
-        KEYBOARD EVENT: LINUX + PATH TO .WEEK
+        KEYBOARD EVENT: PLATFORM-SPECIFIC (see keyboard.hpp) + PATH TO .WEEK
     
     */
 
-    // open keyboard device
-    int fd = open("/dev/input/event4", O_RDONLY | O_NONBLOCK);
-
-    if(fd < 0){
-        std::cerr << "The file couldn't open\n";
-        return EXIT_FAILURE;
-    }
-
-    // initialize libevdev device from file descriptor
-    struct libevdev* dev = nullptr;
-    libevdev_new_from_fd(fd, &dev);
+    initKeyboard();
 
 
     // path to file.week?
@@ -128,8 +120,11 @@ int main(int argc, char* argv[]){
     DigitalClockwork::ADJUSTMENT mode = DigitalClockwork::ADJUSTMENT::DEFAULT;
 
     // terminal config
-    system("clear");
-    system("stty -echo");
+    terminalSetup();
+
+
+    // key edge tracking, replaces the (code, value) pair from the raw event sources
+    KeyState lastKeys = {false, false, false, false, false, false};
 
 
     // Meridiem edge flag
@@ -138,49 +133,41 @@ int main(int argc, char* argv[]){
 
     // updates the clock on each rising edge of the frequency generator
     while(true) {
-        // read keyboard input
-        struct input_event ev;
+        // read keyboard input: current state of each tracked key, platform-specific
+        KeyState curKeys = pollKeys();
 
-        if(libevdev_next_event(dev, LIBEVDEV_READ_FLAG_NORMAL, &ev) == 0){
-            if(ev.type == EV_KEY){
-                // key pressed
-                if(ev.value == 1){
-                    // CLOCKWORK CONFIG KEYS
-                    if(ev.code == KEY_F){
-                        mode = DigitalClockwork::ADJUSTMENT::FAST;
-                    }
-
-                    if(ev.code == KEY_S){
-                        mode = DigitalClockwork::ADJUSTMENT::SLOW;
-                    }
-
-                    // ALARM CONFIG KEYS
-                    if(ev.code == KEY_P){ 
-                        alarm.programAlarm(); 
-                    }
-
-                    if(ev.code == KEY_A){ 
-                        alarm.advanceDay();   
-                    }
-
-                    if(ev.code == KEY_R){ 
-                        alarm.reset();        
-                    }
-
-                    if(ev.code == KEY_D){ 
-                        alarm.disarm();        
-                    }
-                }
-
-                // key released
-                if(ev.value == 0){
-                    if(ev.code == KEY_F || ev.code == KEY_S){
-                        mode = DigitalClockwork::ADJUSTMENT::DEFAULT;
-                    }
-                }
-            }
+        // key pressed (rising edge)
+        if(curKeys.F && !lastKeys.F){
+            mode = DigitalClockwork::ADJUSTMENT::FAST;
         }
-        
+
+        if(curKeys.S && !lastKeys.S){
+            mode = DigitalClockwork::ADJUSTMENT::SLOW;
+        }
+
+        if(curKeys.P && !lastKeys.P){
+            alarm.programAlarm();
+        }
+
+        if(curKeys.A && !lastKeys.A){
+            alarm.advanceDay();
+        }
+
+        if(curKeys.R && !lastKeys.R){
+            alarm.reset();
+        }
+
+        if(curKeys.D && !lastKeys.D){
+            alarm.disarm();
+        }
+
+        // key released (falling edge)
+        if((!curKeys.F && lastKeys.F) || (!curKeys.S && lastKeys.S)){
+            mode = DigitalClockwork::ADJUSTMENT::DEFAULT;
+        }
+
+        lastKeys = curKeys;
+
         // wait for rising edge and update the circuit
         clk.waitEdge(lastState);
         bool curState = clk.getState();
@@ -232,13 +219,10 @@ int main(int argc, char* argv[]){
     
     */
 
-    // stop the frequency generator, the keyboard reader and finish this program
+    // stop the frequency generator, close the keyboard capture and restore the terminal
     clk.stop();
-
-    libevdev_free(dev);
-    close(fd);
-
-    system("stty echo");
+    closeKeyboard();
+    terminalTeardown();
 
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
## Summary

Replaces the Linux-only `libevdev` keyboard reading with a platform-agnostic interface (`include/keyboard.hpp`), backed by one implementation per OS: `keyboard_linux.cpp` (`libevdev`), `keyboard_windows.cpp` (`GetAsyncKeyState`), `keyboard_macintosh.cpp` (`CGEventTap`). `main.cpp` no longer contains any OS-specific code.

## What changed

- `include/keyState.hpp` / `include/keyboard.hpp` — shared key state struct and common interface.
- `src/keyboard_linux.cpp`, `src/keyboard_windows.cpp`, `src/keyboard_macintosh.cpp` — one implementation per platform, only one compiled at a time.
- `src/main.cpp` — uses the interface above instead of `libevdev` directly.
- `Makefile` — detects the host OS and compiles the matching `keyboard_<os>.cpp`; fixes missing `-lasound` on the main binary; splits the old `runClock` target into `clockwork` (build only, no auto-run).
- `README.md` — updated build flow and known limitations.

## Why three separate files

Each OS uses a fundamentally different capture mechanism, decided at compile time. A shared class hierarchy would add indirection with no real benefit, so each file is self-contained and picked by the Makefile. Tradeoff: changes to tracked keys/edge logic need to be replicated in all three (documented in README).

## Testing status

- [x] Linux — built and tested, behavior unchanged from pre-refactor (Ubuntu 26.04 LTS).
- [ ]  Windows — not yet tested.
- [ ] macOS — not yet tested (remember to grant Accessibility permission).

## How to test this project

```bash
make clockwork
./builds/digitalClock input/days.week
```